### PR TITLE
Adds Celery documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,47 @@ Or the Walrus module
     >>> huey['color']
     'white'
 
+
+Celery usage
+============
+
+.. code-block:: python
+
+    # settings.py
+
+    from redislite import Redis
+
+    # Create a Redis instance using redislite
+    REDIS_DB_PATH = os.path.join('/tmp/my_redis.db')
+    rdb = Redis(RDB_PATH)
+    REDIS_SOCKET_PATH = 'redis+socket://%s' % (rdb.socket_file, )
+
+    # Use redislite for the Celery broker
+    BROKER_URL = REDIS_SOCKET_PATH
+
+    # (Optionally) use redislite for the Celery result backend
+    CELERY_RESULT_BACKEND = REDIS_SOCKET_PATH
+
+.. code-block:: python
+    
+    # your_celery_app.py
+
+    from celery import Celery
+
+    # for django projects
+    from django.conf import settings
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
+    celery_app = Celery('my_app')
+    celery_app.config_from_object('django.conf:settings')
+
+    # for other projects
+    celery_app = Celery('my_app')
+    celery_app.config_from_object('settings')
+
+Note that only one Redis instance is created, and others merely discover the running instance and use its existing socket file path.
+
+
+
 More Information
 ================
 


### PR DESCRIPTION
Adds documentation to use redislite with Celery on single machine.

Caveat: there is an issue with `master` right now that if the first machine in the Celery environment which started the redis instance terminates, the other machines in the Celery environment will have a stale `BROKER_URL` representing the old socket file path which was cleaned up/terminated.

We are optimistic that Chris's reference counting may nix this problem.