### PR TITLE
readme addition for gcc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,21 @@ releases they can be installed by running:
 .. code-block::
 
     xcode-select --install
-    
+
+Note redislite and its dependecies use the gcc compiler. On OSX you may run into errors indicating that your
+machine is using clang to compile instead, for example:
+
+.. code-block::
+
+    clang: error: unknown argument: '-mno-fused-madd' [-Wunused-command-line-argument-hard-error-in-future]
+
+If this is the case, set your environment variable to override the use of clang in favor of gcc:
+
+.. code-block::
+
+    CC=gcc
+
+
 Installation
 ============
 


### PR DESCRIPTION
Adds instructions to README to set environment variable using GCC as opposed to CLANG.