### PR TITLE
Config copy defaults

### DIFF
--- a/redislite/configuration.py
+++ b/redislite/configuration.py
@@ -835,7 +835,7 @@ def config(*args, **kwargs):
     """
     global default_settings
 
-    settings = default_settings
+    settings = dict(default_settings)
     settings.update(kwargs)
 
     return template.format(**settings)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -31,6 +31,16 @@ class TestRedislite(unittest.TestCase):
         result = redislite.configuration.config()
         self.assertIn('\ndaemonize yes', result)
 
+
+    def test_configuration_modify_defaults(self):
+        import redislite.configuration
+        result = redislite.configuration.config(daemonize="no")
+        self.assertIn('\ndaemonize no', result)
+
+        # ensure the global defaults are not modified
+        self.assertEquals(redislite.configuration.default_settings["daemonize"], "yes")
+
+
     def test_configuration_settings(self):
         import redislite.configuration
         result = redislite.configuration.settings()


### PR DESCRIPTION
calling configuration.config() makes a copy of default settings (instead of pointing to that global variable)