### PR TITLE
Add code to not cleanup the server if there are other connections to it.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,21 +60,24 @@ On Redhat/Fedora systems, install them with:
 
     yum install python-devel
     
-On Mac OSX you will need the XCode command line utilities installed.  If you do not have xcode installed on recent OSX
-releases they can be installed by running:
+On Mac OSX you may need the XCode command line utilities installed.  If you do
+not have xcode installed on recent OSX releases they can be installed by
+running:
 
 .. code-block::
 
     xcode-select --install
 
-Note redislite and its dependecies use the gcc compiler. On OSX you may run into errors indicating that your
-machine is using clang to compile instead, for example:
+Note redislite and its dependencies use the gcc compiler. On OSX you may run
+into errors indicating that your machine is using clang to compile instead, for
+example:
 
 .. code-block::
 
     clang: error: unknown argument: '-mno-fused-madd' [-Wunused-command-line-argument-hard-error-in-future]
 
-If this is the case, set your environment variable to override the use of clang in favor of gcc:
+If this is the case, set your environment variable to override the use of clang
+in favor of gcc:
 
 .. code-block::
 
@@ -195,6 +198,8 @@ slave of the first instance.
 More Information
 ================
 
-There is more detailed information on the redislite documentation page at http://redislite.readthedocs.org/en/latest/
+There is more detailed information on the redislite documentation page at
+http://redislite.readthedocs.org/en/latest/
 
-Redislite is Free software under the New BSD license, see LICENSE.txt for details
+Redislite is Free software under the New BSD license, see LICENSE.txt for
+details.

--- a/docs/source/topic/troubleshooting.rst
+++ b/docs/source/topic/troubleshooting.rst
@@ -1,3 +1,4 @@
 Troubleshooting redislite
 =========================
 
+

--- a/redislite/client.py
+++ b/redislite/client.py
@@ -67,9 +67,6 @@ class RedisMixin(object):
         :return:
         """
 
-        #if not self.redis_dir:  # pragma: no cover
-        #    return
-
         if self.pid:
             logger.debug('Connection count: %s', self._connection_count())
             if self._connection_count() <= 1:
@@ -367,7 +364,7 @@ class RedisMixin(object):
                     except psutil.NoSuchProcess:
                         return 0
                     if not p.is_running():
-                        return pid
+                        return 0
                 else:  # pragma: no cover
                     return 0
             return int(pid)

--- a/redislite/client.py
+++ b/redislite/client.py
@@ -77,7 +77,8 @@ class RedisMixin(object):
                 )
                 # noinspection PyUnresolvedReferences
                 logger.debug(
-                    'Shutting down redis server with pid of %d' % self.pid)
+                    'Shutting down redis server with pid of %d', self.pid
+                )
                 self.shutdown()
                 self.socket_file = None
 
@@ -112,6 +113,10 @@ class RedisMixin(object):
         self.pidfile = None
 
     def _connection_count(self):
+        """
+        Return the number of active connections to the redis server.
+        :return:
+        """
         if not self._is_redis_running():  # pragma: no cover
             return 0
         active_connections = 0
@@ -197,21 +202,21 @@ class RedisMixin(object):
             return False
 
         if os.path.exists(self.settingregistryfile):
-            with open(self.settingregistryfile) as fh:
-                settings = json.load(fh)
+            with open(self.settingregistryfile) as file_handle:
+                settings = json.load(file_handle)
 
             if not os.path.exists(settings['pidfile']):
                 return False
 
-            with open(settings['pidfile']) as fh:
-                pid = fh.read().strip()   # NOQA
+            with open(settings['pidfile']) as file_handle:
+                pid = file_handle.read().strip()   # NOQA
                 pid = int(pid)
                 if pid:  # pragma: no cover
                     try:
-                        p = psutil.Process(pid)
+                        process = psutil.Process(pid)
                     except psutil.NoSuchProcess:
                         return False
-                    if not p.is_running():
+                    if not process.is_running():
                         return False
                 else:  # pragma: no cover
                     return False
@@ -248,8 +253,8 @@ class RedisMixin(object):
             with open(pidfile) as fh:
                 pid_number = int(fh.read())
             if pid_number:
-                p = psutil.Process(pid_number)
-                if not p.is_running():  # pragma: no cover
+                process = psutil.Process(pid_number)
+                if not process.is_running():  # pragma: no cover
                     logger.warn('Loaded registry for non-existant redis-server')
                     return
         else:  # pragma: no cover
@@ -271,8 +276,7 @@ class RedisMixin(object):
         # If the user is specifying settings we can't configure just pass the
         # request to the redis.Redis module
         if 'host' in kwargs.keys() or 'port' in kwargs.keys():
-            # noinspection PyArgumentList,PyPep8
-            return super(RedisMixin, self).__init__(*args, **kwargs)  # pragma: no cover
+            super(RedisMixin, self).__init__(*args, **kwargs)  # pragma: no cover
 
         self.socket_file = kwargs.get('unix_socket_path', None)
         if self.socket_file and self.socket_file == os.path.basename(self.socket_file):
@@ -356,14 +360,14 @@ class RedisMixin(object):
                 running.
         """
         if self.pidfile and os.path.exists(self.pidfile):
-            with open(self.pidfile) as fh:
-                pid = int(fh.read().strip())
+            with open(self.pidfile) as file_handle:
+                pid = int(file_handle.read().strip())
                 if pid:  # pragma: no cover
                     try:
-                        p = psutil.Process(pid)
+                        process = psutil.Process(pid)
                     except psutil.NoSuchProcess:
                         return 0
-                    if not p.is_running():
+                    if not process.is_running():
                         return 0
                 else:  # pragma: no cover
                     return 0
@@ -410,7 +414,8 @@ class Redis(RedisMixin, redis.Redis):
             argument is not None, the embedded redis server will not be used.
             Defaults to None.
 
-        serverconfig(dict): A dictionary of additional redis-server configuration settings.  All keys and values must be str.
+        serverconfig(dict): A dictionary of additional redis-server
+            configuration settings.  All keys and values must be str.
             Supported keys are:
                 activerehashing,
                 aof_rewrite_incremental_fsync,
@@ -514,7 +519,8 @@ class StrictRedis(RedisMixin, redis.StrictRedis):
             not None, the embedded redis server will not be used.  Defaults to
             None.
 
-        serverconfig(dict): A dictionary of additional redis-server configuration settings.  All keys and values must be str.
+        serverconfig(dict): A dictionary of additional redis-server
+            configuration settings.  All keys and values must be str.
             Supported keys are:
                 activerehashing,
                 aof_rewrite_incremental_fsync,

--- a/redislite/configuration.py
+++ b/redislite/configuration.py
@@ -10,10 +10,12 @@ from jinja2 import Template
 
 
 import logging
+
+
 logger = logging.getLogger(__name__)
 
-template = Template("""
-# Redis configuration file example
+
+REDIS_SERVER_TEMPLATE = Template("""# Redis configuration file example
 
 # Note on units: when memory size is needed, it is possible to specify
 # it in the usual form of 1k 5GB 4M and so forth:
@@ -810,7 +812,9 @@ hz {{ 10 }}
 # big latency spikes.
 aof-rewrite-incremental-fsync {{ aof_rewrite_incremental_fsync }}
 """)
-default_settings = {
+
+
+DEFAULT_REDIS_SETTINGS = {
     'daemonize': 'yes',
     'pidfile': '/var/run/redislite/redis.pid',
     'tcp_backlog': '511',
@@ -857,27 +861,20 @@ default_settings = {
 }
 
 
-def settings(*args, **kwargs):
+def settings(**kwargs):
     """
     Return a config settings based on the defaults and the arguments passed
     :return:
     """
-    global default_settings
-
-    new_settings = default_settings
+    new_settings = dict(DEFAULT_REDIS_SETTINGS)
     new_settings.update(kwargs)
 
     return new_settings
 
 
-def config(*args, **kwargs):
+def config(**kwargs):
     """
     Generate a redis configuration file based on the passed arguments
     :return:
     """
-    global default_settings
-
-    settings = dict(default_settings)
-    settings.update(kwargs)
-
-    return template.render(settings)
+    return REDIS_SERVER_TEMPLATE.render(**settings(**kwargs))

--- a/redislite/patch.py
+++ b/redislite/patch.py
@@ -13,6 +13,8 @@ from .client import Redis, StrictRedis
 
 
 logger = logging.getLogger(__name__)
+
+
 original_classes = collections.defaultdict(lambda: None)  # pragma: no cover
 Redis_Patched = False
 StrictRedis_Patched = False
@@ -68,8 +70,8 @@ def patch_redis_Redis(dbfile=None):
 
 def unpatch_redis_Redis():
     """
-    This class unpatches the :class:`redis.Redis()` class of the redis module and restores the original
-    :class:`redis.Redis()`  class.
+    This class unpatches the :class:`redis.Redis()` class of the redis module
+    and restores the original :class:`redis.Redis()`  class.
 
 
     Example:
@@ -90,7 +92,9 @@ def unpatch_redis_Redis():
 
 def patch_redis_StrictRedis(dbfile=None):
     """
-    This class patches the redis module to replace the :class:`redis.StrictRedis()` class with the redislite enahanced
+    This class patches the redis module to replace the
+    :param dbfile:
+    :class:`redis.StrictRedis()` class with the redislite enhanced
     :class:`redislite.StrictRedis()` class that uses the embedded redis server.
 
 
@@ -99,9 +103,11 @@ def patch_redis_StrictRedis(dbfile=None):
 
 
     Notes:
-        If the dbfile parameter is not passed, each any instances of :class:`redis.StrictRedis()` class with no
-        arguments will get a unique instance of the redis server.  If the dbfile parameter is provided, all instances
-        of :class:`redis.Redis()` will share/reference the same instance of the redis server.
+        If the dbfile parameter is not passed, all :class:`redis.StrictRedis()`
+        class with no arguments will get a separate redis server.  If the
+        dbfile parameter is provided, all instances of the
+        :class:`redis.Redis()` class passed with the same dbfile value
+        will share/reference the same redis server.
 
     Args:
         dbfile(str):
@@ -134,8 +140,8 @@ def patch_redis_StrictRedis(dbfile=None):
 
 def unpatch_redis_StrictRedis():
     """
-    This class unpatches the :class:`redis.StrictRedis()` class of the redis module and restores the original
-    :class:`redis.StrictRedis()`  class.
+    This class unpatches the :class:`redis.StrictRedis()` class of the redis
+    module and restores the original :class:`redis.StrictRedis()`  class.
 
 
     Example:

--- a/redislite/patch.py
+++ b/redislite/patch.py
@@ -20,8 +20,9 @@ StrictRedis_Patched = False
 
 def patch_redis_Redis(dbfile=None):
     """
-    This class patches the redis module to replace the :class:`redis.Redis()` class with the redislite enahanced
-    :class:`redislite.Redis()` class that uses the embedded redis server.
+    This class patches the redis module to replace the :class:`redis.Redis()`
+    class with the redislite enhanced :class:`redislite.Redis()` class that uses
+    the embedded redis server.
 
 
     Example:
@@ -29,22 +30,20 @@ def patch_redis_Redis(dbfile=None):
 
 
     Notes:
-        If the dbfile parameter is not passed, each any instances of redis.Redis() class with no arguments will get a
-        unique instance of the redis server.  If the dbfile parameter is provided, all instances of redis.Redis()
-        class without a host or part argument will share/reference the same instance of the redis server.
+        If the dbfile parameter is not passed, each instance of the
+        redis.Redis() class with no arguments will get a separate redis
+        server.  If the dbfile parameter is provided, all instances of
+        the redis.Redis() class without a host or path argument will
+        share/reference the same redis server.
 
     Args:
         dbfile(str):
-            The name of the Redis db file to be used.  If this argument is passed all instances of the
-            :class:`redis.Redis` class will share a single instance of the embedded redis server.
+            The name of the Redis db file to be used.  If this argument is
+            passed all instances of the :class:`redis.Redis` class will share a
+            single embedded redis server.
 
     Returns:
         This function does not return any values.
-
-
-    Raises:
-
-
     """
     global original_classes
     global Redis_Patched

--- a/redislite/patch.py
+++ b/redislite/patch.py
@@ -54,6 +54,8 @@ def patch_redis_Redis(dbfile=None):
         return
 
     if dbfile:
+        if dbfile == os.path.basename(dbfile):
+            dbfile = os.path.join(os.getcwd(), dbfile)
         Redis.dbdir = os.path.dirname(dbfile)
         Redis.dbfilename = os.path.basename(dbfile)
         Redis.settingregistryfile = os.path.join(
@@ -118,6 +120,8 @@ def patch_redis_StrictRedis(dbfile=None):
         return
 
     if dbfile:
+        if dbfile == os.path.basename(dbfile):
+            dbfile = os.path.join(os.getcwd(), dbfile)
         StrictRedis.dbdir = os.path.dirname(dbfile)
         StrictRedis.dbfilename = os.path.basename(dbfile)
         StrictRedis.settingregistryfile = os.path.join(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,8 +37,6 @@ class TestRedisliteClient(unittest.TestCase):
         by the current user.
         :return:
         """
-        import psutil
-
         processes = []
         for proc in psutil.process_iter():
             try:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -80,7 +80,9 @@ class TestRedisliteConfiguration(unittest.TestCase):
         self.assertIn('\ndaemonize no', result)
 
         # ensure the global defaults are not modified
-        self.assertEquals(redislite.configuration.default_settings["daemonize"], "yes")
+        self.assertEquals(
+            redislite.configuration.DEFAULT_REDIS_SETTINGS["daemonize"], "yes"
+        )
 
 
     def test_configuration_settings(self):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2015, Yahoo Inc.
+# Copyrights licensed under the New BSD License
+# See the accompanying LICENSE.txt file for terms.
+"""
+test_redislite
+----------------------------------
+
+Tests for `redislite` module.
+"""
+from __future__ import print_function
+import getpass
+import inspect
+import logging
+import os
+import redislite
+import unittest
+
+
+logger = logging.getLogger(__name__)
+
+
+# noinspection PyPep8Naming
+class TestRedisliteConfiguration(unittest.TestCase):
+
+    class logger(object):
+        @staticmethod
+        def debug(*args, **kwargs):
+            new_args = list(args)
+            new_args[0] = str(inspect.stack()[1][3]) + ': ' + new_args[0]
+            args=tuple(new_args)
+            return logger.debug(*args, **kwargs)
+
+    def _redis_server_processes(self):
+        """
+        Return count of process objects for all redis-server processes started
+        by the current user.
+        :return:
+        """
+        import psutil
+
+        processes = []
+        for proc in psutil.process_iter():
+            try:
+                if proc.name() == 'redis-server':
+                    if proc.username() == getpass.getuser():
+                        processes.append(proc)
+            except psutil.NoSuchProcess:
+                pass
+
+        return len(processes)
+
+    def _log_redis_pid(self, connection):
+        logger.debug(
+            '%s: r.pid: %d', str(inspect.stack()[1][3]), connection.pid
+        )
+
+    def setUp(self):
+        logger.info(
+            'Start Child processes: %d', self._redis_server_processes()
+        )
+
+    def tearDown(self):
+        logger.info(
+            'End Child processes: %d', self._redis_server_processes()
+        )
+
+    def test_debug(self):
+        import redislite.debug
+        redislite.debug.print_debug_info()
+
+    def test_configuration_config(self):
+        import redislite.configuration
+        result = redislite.configuration.config()
+        self.assertIn('\ndaemonize yes', result)
+
+
+    def test_configuration_modify_defaults(self):
+        import redislite.configuration
+        result = redislite.configuration.config(daemonize="no")
+        self.assertIn('\ndaemonize no', result)
+
+        # ensure the global defaults are not modified
+        self.assertEquals(redislite.configuration.default_settings["daemonize"], "yes")
+
+
+    def test_configuration_settings(self):
+        import redislite.configuration
+        result = redislite.configuration.settings()
+        result_set = set(result.items())
+        expected_subset = set(
+            {
+                'dbdir': './',
+                'daemonize': 'yes',
+                'unixsocketperm': '700',
+                'timeout': '0',
+                'dbfilename': 'redis.db'
+            }.items()
+        )
+        self.assertTrue(
+            expected_subset.issubset(result_set)
+        )
+
+
+    def test_configuration_config_db(self):
+        import redislite.configuration
+        result = redislite.configuration.config(
+                pidfile='/var/run/redislite/test.pid',
+                unixsocket='/var/run/redislite/redis.socket',
+                dbdir=os.getcwd(),
+                dbfilename='test.db',
+        )
+
+        self.assertIn('\ndaemonize yes', result)
+        self.assertIn('\npidfile /var/run/redislite/test.pid', result)
+        self.assertIn('\ndbfilename test.db', result)
+
+    def test_configuration_config_slave(self):
+        import redislite.configuration
+        result = redislite.configuration.config(
+                pidfile='/var/run/redislite/test.pid',
+                unixsocket='/var/run/redislite/redis.socket',
+                dbdir=os.getcwd(),
+                dbfilename='test.db',
+                slaveof='localhost 6397'
+        )
+        self.assertIn(' slaveof localhost 6397', result)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    test_suite = unittest.TestLoader().loadTestsFromTestCase(
+        TestRedisliteConfiguration
+    )
+    unittest.TextTestRunner(verbosity=2).run(test_suite)

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2015, Yahoo Inc.
+# Copyrights licensed under the New BSD License
+# See the accompanying LICENSE.txt file for terms.
+"""
+Tests for `redislite.debug` module.
+"""
+from __future__ import print_function
+import logging
+import redislite
+import unittest
+
+
+logger = logging.getLogger(__name__)
+
+
+# noinspection PyPep8Naming
+class TestRedisliteDebug(unittest.TestCase):
+
+    def test_debug(self):
+        import redislite.debug
+        redislite.debug.print_debug_info()
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    test_suite = unittest.TestLoader().loadTestsFromTestCase(TestRedisliteDebug)
+    unittest.TextTestRunner(verbosity=2).run(test_suite)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2015, Yahoo Inc.
+# Copyrights licensed under the New BSD License
+# See the accompanying LICENSE.txt file for terms.
+"""
+Tests for `redislite` module (__init__.py).
+"""
+from __future__ import print_function
+import logging
+import redislite
+import redislite.patch
+import unittest
+
+
+logger = logging.getLogger(__name__)
+
+
+# noinspection PyPep8Naming
+class TestRedisliteModule(unittest.TestCase):
+    def test_metadata(self):
+        self.assertIsInstance(redislite.__version__, str)
+        self.assertIsInstance(redislite.__git_version__, str)
+        self.assertIsInstance(redislite.__git_origin__, str)
+        self.assertIsInstance(redislite.__git_branch__, str)
+        self.assertIsInstance(redislite.__git_hash__, str)
+        self.assertIsInstance(redislite.__redis_server_info__, dict)
+        self.assertIsInstance(redislite.__redis_executable__, str)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    test_suite = unittest.TestLoader().loadTestsFromTestCase(
+        TestRedisliteModule
+    )
+    unittest.TextTestRunner(verbosity=2).run(test_suite)

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2015, Yahoo Inc.
+# Copyrights licensed under the New BSD License
+# See the accompanying LICENSE.txt file for terms.
+"""
+Tests for `redislite.patch` module.
+"""
+from __future__ import print_function
+import getpass
+import inspect
+import logging
+import os
+import psutil
+import redislite
+import redislite.patch
+import unittest
+
+
+logger = logging.getLogger(__name__)
+
+
+# noinspection PyPep8Naming
+class TestRedislitePatch(unittest.TestCase):
+
+    class logger(object):
+        @staticmethod
+        def debug(*args, **kwargs):
+            new_args = list(args)
+            new_args[0] = str(inspect.stack()[1][3]) + ': ' + new_args[0]
+            args=tuple(new_args)
+            return logger.debug(*args, **kwargs)
+
+    def _redis_server_processes(self):
+        """
+        Return count of process objects for all redis-server processes started
+        by the current user.
+        :return:
+        """
+        processes = []
+        for proc in psutil.process_iter():
+            try:
+                if proc.name() == 'redis-server':
+                    if proc.username() == getpass.getuser():
+                        processes.append(proc)
+            except psutil.NoSuchProcess:
+                pass
+
+        return len(processes)
+
+    def _log_redis_pid(self, connection):
+        logger.debug(
+            '%s: r.pid: %d', str(inspect.stack()[1][3]), connection.pid
+        )
+
+    def setUp(self):
+        logger.info(
+            'Start Child processes: %d', self._redis_server_processes()
+        )
+
+    def tearDown(self):
+        logger.info(
+            'End Child processes: %d', self._redis_server_processes()
+        )
+
+    def test_redislite_patch_redis_Redis(self):
+        redislite.patch.patch_redis_Redis()
+        import redis
+        r = redis.Redis()
+        self._log_redis_pid(r)
+        self.assertIsInstance(r.pid, int)    # Should have a redislite pid
+        redislite.patch.unpatch_redis_Redis()
+
+    def test_redislite_patch_redis_StrictRedis(self):
+        redislite.patch.patch_redis_StrictRedis()
+        import redis
+        r = redis.StrictRedis()
+        self._log_redis_pid(r)
+        self.assertIsInstance(r.pid, int)    # Should have a redislite pid
+        redislite.patch.unpatch_redis_StrictRedis()
+
+    # noinspection PyUnusedLocal
+    def test_redislite_patch_redis(self):
+        redislite.patch.patch_redis()
+        import redis
+        r = redis.Redis()
+        self._log_redis_pid(r)
+        self.assertIsInstance(r.pid, int)    # Should have a redislite pid
+        s = redis.StrictRedis()
+        self._log_redis_pid(s)
+        self.assertIsInstance(s.pid, int)    # Should have a redislite pid
+        redislite.patch.unpatch_redis()
+
+    def test_redislite_double_patch_redis(self):
+        import redis
+        original_redis = redis.Redis
+        redislite.patch.patch_redis()
+        self.assertNotEqual(original_redis, redis.Redis)
+        redislite.patch.patch_redis()
+        self.assertNotEqual(original_redis, redis.Redis)
+        redislite.patch.unpatch_redis()
+        self.assertEqual(original_redis, redis.Redis)
+
+    def test_redislite_patch_redis_with_dbfile(self):
+        dbfilename = '/tmp/test_redislite_patch_redis_with_dbfile.db'
+        if os.path.exists(dbfilename):
+            os.remove(dbfilename)
+        redislite.patch.patch_redis(dbfilename)
+        import redis
+        r = redis.Redis()
+        self._log_redis_pid(r)
+        self.assertIsInstance(r.pid, int)    # Should have a redislite pid
+        s = redis.Redis()
+        self._log_redis_pid(s)
+        self.assertIsInstance(r.pid, int)    # Should have a redislite pid
+
+        # Both instances should be talking to the same redis server
+        self.assertEqual(r.pid, s.pid)
+        redislite.patch.unpatch_redis()
+
+    def test_redislite_patch_redis_with_dbfile(self):
+        dbfilename = 'test_redislite_patch_redis_with_short_dbfile.db'
+        if os.path.exists(dbfilename):
+            os.remove(dbfilename)
+        redislite.patch.patch_redis(dbfilename)
+        import redis
+        r = redis.Redis()
+        self._log_redis_pid(r)
+        self.assertIsInstance(r.pid, int)    # Should have a redislite pid
+        s = redis.Redis()
+        self._log_redis_pid(s)
+        self.assertIsInstance(r.pid, int)    # Should have a redislite pid
+
+        # Both instances should be talking to the same redis server
+        self.assertEqual(r.pid, s.pid)
+        redislite.patch.unpatch_redis()
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    test_suite = unittest.TestLoader().loadTestsFromTestCase(TestRedislitePatch)
+    unittest.TextTestRunner(verbosity=2).run(test_suite)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -259,6 +259,23 @@ class TestRedislite(unittest.TestCase):
         self.assertEqual(r.pid, s.pid)
         redislite.patch.unpatch_redis()
 
+    def test_redislite_patch_redis_with_dbfile(self):
+        dbfilename = 'test_redislite_patch_redis_with_short_dbfile.db'
+        if os.path.exists(dbfilename):
+            os.remove(dbfilename)
+        redislite.patch.patch_redis(dbfilename)
+        import redis
+        r = redis.Redis()
+        self._log_redis_pid(r)
+        self.assertIsInstance(r.pid, int)    # Should have a redislite pid
+        s = redis.Redis()
+        self._log_redis_pid(s)
+        self.assertIsInstance(r.pid, int)    # Should have a redislite pid
+
+        # Both instances should be talking to the same redis server
+        self.assertEqual(r.pid, s.pid)
+        redislite.patch.unpatch_redis()
+
     def test_redislite_Redis_create_redis_directory_tree(self):
         r = redislite.Redis()
         self._log_redis_pid(r)


### PR DESCRIPTION
Added code to only run cleanup if the server connection count == 1 so the redis server will not terminate if it's still in use.

Add test to verify the server doesn't go away if the first redislite instance pointing to it goes away.