### PR TITLE
Set log file full path in Redis server config file

### DIFF
--- a/redislite/client.py
+++ b/redislite/client.py
@@ -133,6 +133,7 @@ class RedisMixin(object):
                 'Creating temporary redis directory %s', self.redis_dir
             )
             self.pidfile = os.path.join(self.redis_dir, 'redis.pid')
+            self.logfile = os.path.join(self.redis_dir, 'redis.log')
             if not self.socket_file:
                 self.socket_file = os.path.join(self.redis_dir, 'redis.socket')
 
@@ -150,6 +151,7 @@ class RedisMixin(object):
         kwargs.update(
             {
                 'pidfile': self.pidfile,
+                'logfile': kwargs.get('logfile', self.logfile),
                 'unixsocket': self.socket_file,
                 'dbdir': self.dbdir,
                 'dbfilename': self.dbfilename


### PR DESCRIPTION
Fix issue #81 

With this solution, if `logfile` key is not set in `serverconfig` dictionary, the Redis server log file will be created in the temporary directory, regardless of the database filename path given when creating an instance.