### PR TITLE
Deal with the server being busy when it is starting up.

### DIFF
--- a/redislite/client.py
+++ b/redislite/client.py
@@ -219,7 +219,8 @@ class RedisMixin(object):
             time.sleep(.1)
         if timeout:  # pragma: no cover
             raise RedisLiteServerStartError(
-                'The redis-server process failed to start'
+                'The redis-server process failed to start; unreachable after '
+                '{0} seconds'.format(self.start_timeout)
             )
 
     def _is_redis_running(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -293,6 +293,8 @@ class TestRedisliteClient(unittest.TestCase):
         db._cleanup()
         del db
         db = redislite.StrictRedis('bug.redis')
+        if os.path.exists('bug.redis'):
+            os.remove('bug.redis')
 
 
 if __name__ == '__main__':

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -279,6 +279,21 @@ class TestRedisliteClient(unittest.TestCase):
         with self.assertRaises(ConnectionError):
             redislite.Redis(port=1).keys()
 
+    def test_shutdown_race_condition(self):
+        """
+        Test that there is no race condition when a shutdown is run after
+        a large data operation.
+        """
+        if os.path.exists('bug.redis'):
+            os.remove('bug.redis')
+        db = redislite.StrictRedis('bug.redis')
+        for key in range(10000):
+            db.hset("h1", os.urandom(32), " " * 65536)
+        db.save()
+        db._cleanup()
+        del db
+        db = redislite.StrictRedis('bug.redis')
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
This is to deal with #98, it puts the code specified that causes the error into a test and adds an additional method to wait until the server returns not busy.