### PR TITLE
Give a better exception message

### DIFF
--- a/redislite/client.py
+++ b/redislite/client.py
@@ -26,7 +26,7 @@ from . import configuration
 from . import __redis_executable__
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 
 class RedisLiteException(Exception):

--- a/redislite/configuration.py
+++ b/redislite/configuration.py
@@ -9,7 +9,7 @@ import logging
 from copy import copy
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 
 DEFAULT_REDIS_SETTINGS = {

--- a/redislite/debug.py
+++ b/redislite/debug.py
@@ -46,10 +46,10 @@ the module and it's build information.
 """
 from __future__ import print_function
 from distutils.spawn import find_executable
+import os
 from .__init__ import __version__, __git_version__, __source_url__, \
     __git_hash__, __git_origin__, __git_branch__, __redis_server_info__, \
     __redis_executable__
-import os
 
 
 def debug_info_list():

--- a/redislite/patch.py
+++ b/redislite/patch.py
@@ -12,7 +12,7 @@ import redis
 from .client import Redis, StrictRedis
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 
 original_classes = collections.defaultdict(lambda: None)  # pragma: no cover
@@ -111,8 +111,9 @@ def patch_redis_StrictRedis(dbfile=None):
 
     Args:
         dbfile(str):
-            The name of the Redis db file to be used.  If this argument is passed all instances of the
-            :class:`redis.Redis` class will share a single instance of the embedded redis server.
+            The name of the Redis db file to be used.  If this argument is
+            passed all instances of the :class:`redis.Redis` class will share
+            a single instance of the embedded redis server.
 
     Returns:
         This function does not return any values.
@@ -170,14 +171,17 @@ def patch_redis(dbfile=None):
 
 
     Notes:
-        If the dbfile parameter is not passed, each any instances of :class:`redis.StrictRedis()` class with no
-        arguments will get a unique instance of the redis server.  If the dbfile parameter is provided, all instances
-        of :class:`redis.Redis()` will share/reference the same instance of the redis server.
+        If the dbfile parameter is not passed, each any instances of
+        :class:`redis.StrictRedis()` class with no arguments will get a unique
+        instance of the redis server.  If the dbfile parameter is provided, all
+        instances of :class:`redis.Redis()` will share/reference the same
+        instance of the redis server.
 
     Args:
         dbfile(str):
-            The name of the Redis db file to be used.  If this argument is passed all instances of the
-            :class:`redis.Redis()` class will share a single instance of the embedded redis server.
+            The name of the Redis db file to be used.  If this argument is
+            passed all instances of the :class:`redis.Redis()` class will
+            share a single instance of the embedded redis server.
 
     Returns:
         This function does not return any values.
@@ -188,7 +192,8 @@ def patch_redis(dbfile=None):
 
 def unpatch_redis():
     """
-    Unpatch all the redis classes provided by :mod:`redislite` that have been patched.
+    Unpatch all the redis classes provided by :mod:`redislite` that have been
+    patched.
 
     Example:
         unpatch_redis()

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ class InstallRedis(install):
                     )
             # Store the redis-server --version output for later
             for line in os.popen('%s --version' % md['redis_bin']).readlines():
-                line = line.decode().strip()
+                line = line.strip()
                 for item in line.split():
                     if '=' in item:
                         key, value = item.split('=')

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,13 @@ from setuptools.command.install import install
 from distutils.command.build import build
 from distutils.core import Extension
 import distutils.util
+import sys
 from subprocess import call
 
 
 logger = logging.getLogger(__name__)
+
+UNSUPPORTED_PLATFORMS = ['win32', 'win64']
 METADATA_FILENAME = 'redislite/package_metadata.json'
 BASEPATH = os.path.dirname(os.path.abspath(__file__))
 REDIS_PATH = os.path.join(BASEPATH, 'redis.submodule')
@@ -27,7 +30,7 @@ def readme():
         return f.read()
 
 
-class build_redis(build):
+class BuildRedis(build):
     global REDIS_SERVER_METADATA
 
     def run(self):
@@ -71,9 +74,10 @@ class build_redis(build):
 
 
 class InstallRedis(install):
+    build_scripts = None
+
     def initialize_options(self):
         install.initialize_options(self)
-        self.build_scripts = None
 
     def finalize_options(self):
         install.finalize_options(self)
@@ -115,7 +119,8 @@ class InstallRedis(install):
                     )
             # Store the redis-server --version output for later
             for line in os.popen('%s --version' % md['redis_bin']).readlines():
-                for item in line.strip().split():
+                line = line.decode().strip()
+                for item in line.split():
                     if '=' in item:
                         key, value = item.split('=')
                         REDIS_SERVER_METADATA[key] = value
@@ -167,7 +172,7 @@ args = {
     },
     'include_package_data': True,
     'cmdclass': {
-        'build': build_redis,
+        'build': BuildRedis,
         'install': InstallRedis,
     },
 
@@ -265,6 +270,14 @@ def get_and_update_metadata():
 
 
 if __name__ == '__main__':
+    if sys.platform in UNSUPPORTED_PLATFORMS:
+        print(
+            'The redislite module is not supported on the %r '
+            'platform' % sys.platform,
+            file=sys.stderr
+        )
+        sys.exit(1)
+
     os.environ['CC'] = 'gcc'
 
     logging.basicConfig(level=logging.INFO)

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -132,6 +132,10 @@ class TestRedislitePatch(unittest.TestCase):
         # Both instances should be talking to the same redis server
         self.assertEqual(r.pid, s.pid)
         redislite.patch.unpatch_redis_StrictRedis()
+        r._cleanup()
+        s._cleanup()
+        if os.path.exists(dbfilename):
+            os.remove(dbfilename)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This addresses #101 
It changes the setup.py to give a reasonable error on unsupported (I.E. windows) platforms.

It also has a couple of pep8/pylint fixes.

Cleanup from the test_patch.py fix a bit better.