### PR TITLE
Make DB paths with spaces (and other special chars) work

### DIFF
--- a/redislite/configuration.py
+++ b/redislite/configuration.py
@@ -99,8 +99,9 @@ def config(**kwargs):
     """
     # Get our settings
     config_dict = settings(**kwargs)
-    config_dict['dir'] = config_dict['dbdir']
+    config_dict['dir'] = repr(config_dict['dbdir'])
     del config_dict['dbdir']
+    config_dict['dbfilename'] = repr(config_dict['dbfilename'])
 
     configuration = ''
     keys = list(config_dict.keys())

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -109,13 +109,14 @@ class TestRedisliteConfiguration(unittest.TestCase):
         result = redislite.configuration.config(
                 pidfile='/var/run/redislite/test.pid',
                 unixsocket='/var/run/redislite/redis.socket',
-                dbdir=os.getcwd(),
+                dbdir='/tmp/test',
                 dbfilename='test.db',
         )
 
         self.assertIn('\ndaemonize yes', result)
         self.assertIn('\npidfile /var/run/redislite/test.pid', result)
-        self.assertIn('\ndbfilename test.db', result)
+        self.assertIn('\ndbfilename \'test.db\'', result)
+        self.assertIn('\ndir \'/tmp/test\'', result)
 
     def test_configuration_config_slave(self):
         import redislite.configuration


### PR DESCRIPTION
To reproduce:

```
% python -c "import redislite ; redislite.StrictRedis('/tmp/foo bar.tmp')"
...
redislite.client.RedisLiteException: The binary redis-server failed to start
```