### PR TITLE
Handle dbfilename with spaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,23 +70,12 @@ Installing on Mac OSX
 Redislite for OSX comes as a wheel package by default that can be installed
 using current versions of pip.
 
-To install Redislite on MacOSX using the sdist package instead you may need
+To install Redislite on MacOSX using the sdist package instead you will need
 the XCode command line utilities installed.  If you do not have xcode
 installed on recent OSX releases they can be installed by
 running::
 
     xcode-select --install
-
-Note redislite and its dependencies use the gcc compiler. On OSX you may run
-into errors indicating that your machine is using clang to compile instead, for
-example::
-
-    clang: error: unknown argument: '-mno-fused-madd' [-Wunused-command-line-argument-hard-error-in-future]
-
-If this is the case, set your environment variable to override the use of clang
-in favor of gcc::
-
-    CC=gcc
 
 
 Installation

--- a/redislite/client.py
+++ b/redislite/client.py
@@ -363,9 +363,9 @@ class RedisMixin(object):
             self.dbfilename = os.path.basename(db_filename)
             self.dbdir = os.path.dirname(db_filename)
 
-            self.settingregistryfile = os.path.join(
+            self.settingregistryfile = repr(os.path.join(
                 self.dbdir, self.dbfilename + '.settings'
-            )
+            )).strip("'")
 
         logger.debug('Setting up redis with rdb file: %s', self.dbfilename)
         logger.debug('Setting up redis with socket file: %s', self.socket_file)
@@ -380,9 +380,9 @@ class RedisMixin(object):
 
             if not self.dbdir:
                 self.dbdir = self.redis_dir
-                self.settingregistryfile = os.path.join(
+                self.settingregistryfile = repr(os.path.join(
                     self.dbdir, self.dbfilename + '.settings'
-                )
+                )).strip("'")
             self._start_redis()
 
         kwargs['unix_socket_path'] = self.socket_file

--- a/redislite/client.py
+++ b/redislite/client.py
@@ -282,6 +282,7 @@ class RedisMixin(object):
         logger.debug('loading settings, found: %s', settings)
         pidfile = settings.get('pidfile', '')
         if os.path.exists(pidfile):
+            # noinspection PyUnusedLocal
             pid_number = 0
             with open(pidfile) as fh:
                 pid_number = int(fh.read())
@@ -289,7 +290,7 @@ class RedisMixin(object):
                 process = psutil.Process(pid_number)
                 if not process.is_running():  # pragma: no cover
                     logger.warn(
-                        'Loaded registry for non-existant redis-server'
+                        'Loaded registry for non-existent redis-server'
                     )
                     return
         else:  # pragma: no cover
@@ -328,6 +329,7 @@ class RedisMixin(object):
         # If the user is specifying settings we can't configure just pass the
         # request to the redis.Redis module
         if 'host' in kwargs.keys() or 'port' in kwargs.keys():
+            # noinspection PyArgumentList
             super(RedisMixin, self).__init__(
                 *args, **kwargs
             )  # pragma: no cover
@@ -386,6 +388,7 @@ class RedisMixin(object):
         kwargs['unix_socket_path'] = self.socket_file
         # noinspection PyArgumentList
         logger.debug('Calling binding with %s, %s', args, kwargs)
+        # noinspection PyArgumentList
         super(RedisMixin, self).__init__(*args, **kwargs)  # pragma: no cover
 
         logger.debug("Pinging the server to ensure we're connected")
@@ -483,6 +486,8 @@ class RedisMixin(object):
             return int(pid)
         return 0  # pragma: no cover
 
+
+# noinspection PyUnresolvedReferences
 class Redis(RedisMixin, redis.Redis):
     """
     This class provides an enhanced version of the :class:`redis.Redis()` class
@@ -568,13 +573,20 @@ class Redis(RedisMixin, redis.Redis):
 
     Attributes
     ----------
-    db : string
+
+    db : str
         The fully qualified filename associated with the redis dbfilename
         configuration setting.  This attribute is read only.
+
+    logfile : str
+        The name of the redis-server logfile
 
     pid :int
         Pid of the running embedded redis server, this attribute is read
         only.
+
+    redis_log : str
+        The contents of the redis-server log file
 
     start_timeout : float
         Number of seconds to wait for the redis-server process to start
@@ -583,6 +595,7 @@ class Redis(RedisMixin, redis.Redis):
     pass
 
 
+# noinspection PyUnresolvedReferences
 class StrictRedis(RedisMixin, redis.StrictRedis):
     """
     This class provides an enhanced version of the :class:`redis.StrictRedis()`

--- a/redislite/configuration.py
+++ b/redislite/configuration.py
@@ -16,7 +16,7 @@ DEFAULT_REDIS_SETTINGS = {
     'activerehashing': 'yes',
     'aof-rewrite-incremental-fsync': 'yes',
     'appendonly': 'no',
-    'appendfilename': '"appendonly.aof"',
+    'appendfilename': 'appendonly.aof',
     'appendfsync': 'everysec',
     'aof-load-truncated': 'yes',
     'auto-aof-rewrite-percentage': '100',
@@ -26,34 +26,34 @@ DEFAULT_REDIS_SETTINGS = {
     'databases': '16',
     'dbdir': './',
     'dbfilename': 'redis.db',
+    'hash-max-ziplist-entries': '512',
+    'hash-max-ziplist-value': '64',
+    'hll-sparse-max-bytes': '3000',
+    'hz': '10',
+    'list-max-ziplist-entries': '512',
+    'list-max-ziplist-value': '64',
     'loglevel': 'notice',
     'logfile' : 'redis.log',
+    'lua-time-limit': '5000',
     'pidfile': '/var/run/redislite/redis.pid',
     'port': '0',
     'save': ['900 1', '300 100', '60 200', '15 1000'],
+    'stop-writes-on-bgsave-error': 'yes',
     'tcp-backlog': '511',
     'tcp-keepalive': '0',
-    'stop-writes-on-bgsave-error': 'yes',
     'rdbcompression': 'yes',
     'rdbchecksum': 'yes',
-    'timeout': '0',
     'slave-serve-stale-data': 'yes',
     'slave-read-only': 'yes',
     'repl-disable-tcp-nodelay': 'no',
     'slave-priority': '100',
     'no-appendfsync-on-rewrite': 'no',
-    'lua-time-limit': '5000',
     'slowlog-log-slower-than': '10000',
     'slowlog-max-len': '128',
     'latency-monitor-threshold': '0',
     'notify-keyspace-events': '""',
-    'hash-max-ziplist-entries': '512',
-    'hash-max-ziplist-value': '64',
-    'list-max-ziplist-entries': '512',
-    'list-max-ziplist-value': '64',
     'set-max-intset-entries': '512',
-    'hll-sparse-max-bytes': '3000',
-    'hz': '10',
+    'timeout': '0',
     'unixsocket': '/var/run/redislite/redis.socket',
     'unixsocketperm': '700',
     'zset-max-ziplist-entries': '128',
@@ -105,9 +105,10 @@ def config_line(setting, value):
     str
         The configuration line based on the setting and value
     """
-    if setting in ['dbfilename', 'dbdir']:
-        if ' ' in value and '"' not in value:
-            value = '"' + str(value) + '"'
+    if setting in [
+        'appendfilename', 'dbfilename', 'dbdir', 'dir', 'pidfile', 'unixsocket'
+    ]:
+        value = repr(value)
     return '{setting} {value}'.format(setting=setting, value=value)
 
 

--- a/redislite/configuration.py
+++ b/redislite/configuration.py
@@ -18,6 +18,7 @@ DEFAULT_REDIS_SETTINGS = {
     'appendonly': 'no',
     'appendfilename': '"appendonly.aof"',
     'appendfsync': 'everysec',
+    'aof-load-truncated': 'yes',
     'auto-aof-rewrite-percentage': '100',
     'auto-aof-rewrite-min-size': '64mb',
     'bind': None,
@@ -25,15 +26,13 @@ DEFAULT_REDIS_SETTINGS = {
     'databases': '16',
     'dbdir': './',
     'dbfilename': 'redis.db',
+    'loglevel': 'notice',
+    'logfile' : 'redis.log',
     'pidfile': '/var/run/redislite/redis.pid',
     'port': '0',
     'save': ['900 1', '300 100', '60 200', '15 1000'],
     'tcp-backlog': '511',
-    'unixsocket': '/var/run/redislite/redis.socket',
-    'unixsocketperm': '700',
     'tcp-keepalive': '0',
-    'loglevel': 'notice',
-    'logfile' : 'redis.log',
     'stop-writes-on-bgsave-error': 'yes',
     'rdbcompression': 'yes',
     'rdbchecksum': 'yes',
@@ -43,7 +42,6 @@ DEFAULT_REDIS_SETTINGS = {
     'repl-disable-tcp-nodelay': 'no',
     'slave-priority': '100',
     'no-appendfsync-on-rewrite': 'no',
-    'aof-load-truncated': 'yes',
     'lua-time-limit': '5000',
     'slowlog-log-slower-than': '10000',
     'slowlog-max-len': '128',
@@ -54,10 +52,12 @@ DEFAULT_REDIS_SETTINGS = {
     'list-max-ziplist-entries': '512',
     'list-max-ziplist-value': '64',
     'set-max-intset-entries': '512',
-    'zset-max-ziplist-entries': '128',
-    'zset-max-ziplist-value': '64',
     'hll-sparse-max-bytes': '3000',
     'hz': '10',
+    'unixsocket': '/var/run/redislite/redis.socket',
+    'unixsocketperm': '700',
+    'zset-max-ziplist-entries': '128',
+    'zset-max-ziplist-value': '64',
 }
 
 
@@ -107,7 +107,7 @@ def config_line(setting, value):
     """
     if setting in ['dbfilename', 'dbdir']:
         if ' ' in value and '"' not in value:
-            value = '"' + value + '"'
+            value = '"' + str(value) + '"'
     return '{setting} {value}'.format(setting=setting, value=value)
 
 

--- a/redislite/configuration.py
+++ b/redislite/configuration.py
@@ -88,6 +88,29 @@ def settings(**kwargs):
     return new_settings
 
 
+def config_line(setting, value):
+    """
+    Generate a single configuration line based on the setting and value
+
+    Parameters
+    ----------
+    setting : str
+        The configuration setting
+
+    value : str
+        The value for the configuration setting
+
+    Returns
+    -------
+    str
+        The configuration line based on the setting and value
+    """
+    if setting in ['dbfilename', 'dbdir']:
+        if ' ' in value and '"' not in value:
+            value = '"' + value + '"'
+    return '{setting} {value}'.format(setting=setting, value=value)
+
+
 def config(**kwargs):
     """
     Generate a redis configuration file based on the passed arguments
@@ -109,13 +132,13 @@ def config(**kwargs):
         if config_dict[key]:
             if isinstance(config_dict[key], list):
                 for item in config_dict[key]:
-                    configuration += '{key} {value}\n'.format(
-                        key=key, value=item
-                    )
+                    configuration += config_line(
+                        setting=key, value=item
+                    ) + '\n'
             else:
-                configuration += '{key} {value}\n'.format(
-                    key=key, value=config_dict[key]
-                )
+                configuration += config_line(
+                    setting=key, value=config_dict[key]
+                ) + '\n'
         else:
             del config_dict[key]
     logger.debug('Using configuration: %s', configuration)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -293,8 +293,44 @@ class TestRedisliteClient(unittest.TestCase):
         db._cleanup()
         del db
         db = redislite.StrictRedis('bug.redis')
+        db._cleanup()
         if os.path.exists('bug.redis'):
             os.remove('bug.redis')
+
+    def test_redis_log_attribute(self):
+        r = redislite.StrictRedis()
+        self.assertIn('Server started, Redis version', r.redis_log)
+
+    def test_redis_log_tail(self):
+        r = redislite.StrictRedis()
+        lines = r.redis_log_tail(2)
+        self.assertIsInstance(lines, list)
+        self.assertEqual(len(lines), 2)
+
+    def test_redis_log_many_lines(self):
+        r = redislite.StrictRedis()
+        lines = r.redis_log_tail(lines=99999)
+        self.assertIsInstance(lines, list)
+
+    def test_redis_log_small_chunks(self):
+        r = redislite.StrictRedis()
+        lines = r.redis_log_tail(4, width=20)
+        self.assertIsInstance(lines, list)
+        self.assertEqual(len(lines), 4)
+
+    def test_redis_log_tail_no_log(self):
+        r = redislite.StrictRedis()
+        if os.path.exists(r.logfile):
+            os.remove(r.logfile)
+        lines = r.redis_log_tail()
+        self.assertEqual(lines, [])
+
+    def test_redis_log_tail_empty_log(self):
+        r = redislite.StrictRedis()
+        with open(r.logfile, 'w'):
+            pass
+        lines = r.redis_log_tail()
+        self.assertEqual(lines, [])
 
 
 if __name__ == '__main__':

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -78,7 +78,7 @@ class TestRedisliteConfiguration(unittest.TestCase):
         result = redislite.configuration.config_line(
             'dbfilename', 'test file.db'
         )
-        self.assertEqual('dbfilename "test file.db"', result)
+        self.assertEqual("dbfilename 'test file.db'", result)
 
     def test_configuration_config(self):
         result = redislite.configuration.config()
@@ -123,12 +123,12 @@ class TestRedisliteConfiguration(unittest.TestCase):
         )
 
         self.assertIn('\ndaemonize yes', result)
-        self.assertIn('\npidfile ' + pidfile, result)
-        self.assertIn('\ndbfilename test.db', result)
+        self.assertIn('\npidfile ' + repr(pidfile), result)
+        self.assertIn("\ndbfilename 'test.db'", result)
 
     def test_configuration_config_db_with_space(self):
-        pidfile = os.path.join(self.tempdir, 'test.pid')
-        unixsocket = os.path.join(self.tempdir, 'redis.socket')
+        pidfile = os.path.join(self.tempdir, 'test space.pid')
+        unixsocket = os.path.join(self.tempdir, 'test space.socket')
         result = redislite.configuration.config(
             pidfile=pidfile,
             unixsocket=unixsocket,
@@ -137,8 +137,8 @@ class TestRedisliteConfiguration(unittest.TestCase):
         )
 
         self.assertIn('\ndaemonize yes', result)
-        self.assertIn('\npidfile ' + pidfile, result)
-        self.assertIn('\ndbfilename "test space.db"', result)
+        self.assertIn('\npidfile ' + repr(pidfile), result)
+        self.assertIn("\ndbfilename 'test space.db'", result)
 
     def test_configuration_config_slave(self):
         result = redislite.configuration.config(

--- a/tests/test_slave.py
+++ b/tests/test_slave.py
@@ -8,27 +8,18 @@ test_redislite
 Tests for `redislite` module.
 """
 from __future__ import print_function
-import logging
-import os
 import time
-import redis
 import redislite
-import redislite.patch
-import shutil
-import stat
-import tempfile
 import unittest
-import subprocess
 
 
 # noinspection PyPep8Naming
 class TestRedisliteSlave(unittest.TestCase):
 
     def test_slave(self):
-        self.master = redislite.Redis(serverconfig={'port': '7000'})
-        self.master.set('key', 'value')
+        master = redislite.Redis(serverconfig={'port': '7000'})
+        slave = redislite.Redis(serverconfig={'slaveof': 'localhost 7000'})
+        master.set('key', 'value')
         time.sleep(.5)
-        s = redislite.Redis(serverconfig={'slaveof': 'localhost 7000'})
-        value = s.get('key').decode(encoding='UTF-8')
+        value = slave.get('key').decode(encoding='UTF-8')
         self.assertEquals(value, 'value')
-


### PR DESCRIPTION
This pull requests improves the log output when this issue occurs.
- It adds a method and attribute to access the redis-server log.
- All the code that generates a server failed to start error has been updated to always dump the redis-server.log to the python logger prior to generating the exception.
- Additional tests where added to test-client.py to test the new redis_log method and attribute

This pull requests fixes some test/code coverage issues.
- It fixes a number of tests to use a temp directory instead of the current working directory to prevent parallel test runs against multiple python interpreters from stepping on each other.
- An additional test was added to test_patch.py to test an uncovered code path.

This pull request fixes the issue handling db files with spaces in them.
- Added a config_line() function that generates a properly formatted redis server configuration line and properly handles adding quotes around the dbfilename and dbdir settings if the values contain a string.
- Added tests for the new config_line() function.

Misc Lint/PEP8 cleanups
