### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,12 +87,6 @@ To install redislite, simply:
 
     $ pip install redislite
 
-or using easy_install:
-
-.. code-block::
-
-    $ easy_install redislite
-
 or from source:
 
 .. code-block::


### PR DESCRIPTION
Using easy_install doesn't work since it doesn't run the build steps.  This removes easy_install from the instructions.

This should address #106 