### PR TITLE
Debian packaging changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
   fast_finish: true
   allow_failures:
     - env:
+      - TOX_ENV=py35
+      - TOX_ENV=py36
       - TOX_ENV=pypy
       - TOX_ENV=build_docs
 install:

--- a/setup.py
+++ b/setup.py
@@ -277,6 +277,13 @@ def get_and_update_metadata():
     if not os.path.exists('.git') and os.path.exists(METADATA_FILENAME):
         with open(METADATA_FILENAME) as fh:
             metadata = json.load(fh)
+    elif os.path.exists(METADATA_FILENAME) and os.environ.get('REDISLITE_SERVER_BIN', None):
+        with open(METADATA_FILENAME) as fh:
+            metadata = json.load(fh)
+        metadata['redis_server'] = REDIS_SERVER_METADATA
+        metadata['redis_bin'] = os.environ['REDISLITE_SERVER_BIN']
+        with open(METADATA_FILENAME, 'w') as fh:
+            json.dump(metadata, fh, indent=4)
     else:
         git = Git(version=setup_arguments['version'])
         metadata = {

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ deps=
 commands=
     nosetests --exe --with-xunit --xunit-file=nosetests.xml --with-coverage --cover-xml --cover-erase  --cover-package=redislite --cover-xml-file=cobertura.xml tests
 
+passenv=REDISLITE_SERVER_BIN
+
 [testenv:build_docs]
 deps=
     sphinx


### PR DESCRIPTION
Debian doesn't want us using an embedded redis-server.  
These changes allow setting an environment variable before running setup.py to specify a python
interpreter to use.
