### PR TITLE
Update screwdriver.yaml

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -26,3 +26,15 @@ jobs:
       PUBLISH: True
       TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
     requires: [validate_test, validate_lint, validate_codestyle, generate_version]
+
+  verify_test_package:
+    template: python/validate_pypi_package
+    environment:
+        PYPI_INDEX_URL: https://test.pypi.org/simple
+    requires: [publish_test_pypi]
+
+  publish_pypi:
+    template: python/package_python
+    environment:
+      PUBLISH: True
+    requires: [verify_test_package]


### PR DESCRIPTION
Add jobs to validate package install from test pypi and publish to prod pypi

## Description

This adds 2 additional jobs to the CI pipeline:
- verify_test_package - Install the package from the test.pypi.org to validate it installs from the repo correctly.
- publish_pypi - Publish the package to the production pypi repository.

I confirm that this contribution is made under the terms of your choice and that I have the authority necessary to make this contribution on behalf of its copyright owner.
