### PR TITLE
Remove quotes around `python_requires` in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires=
     setuptools>38.0
 packages=
     redislite
-python_requires = >="2.7.11"
+python_requires = >=2.7.11
 
 [screwdrivercd.version]
 version_type = sdv4_SD_BUILD


### PR DESCRIPTION
I'm trying to install redislite via poetry, however it is not able to parse `python_requires` version as it's in quotes, whereas majority of other packages don't include quotes (per PEP 345 and PEP 440). This PR removes the quotes, which shouldn't affect any other functionality

---

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
