### PR TITLE
Explicitly link with libatomic if on ARM (Fixes #150)

### DIFF
--- a/redis.submodule/src/Makefile
+++ b/redis.submodule/src/Makefile
@@ -77,6 +77,15 @@ FINAL_LDFLAGS=$(LDFLAGS) $(REDIS_LDFLAGS) $(DEBUG)
 FINAL_LIBS=-lm
 DEBUG=-g -ggdb
 
+# Linux ARM needs -latomic at linking time
+ifneq (,$(filter aarch64 armv,$(uname_M)))
+        FINAL_LIBS+=-latomic
+else
+ifneq (,$(findstring armv,$(uname_M)))
+        FINAL_LIBS+=-latomic
+endif
+endif
+
 ifeq ($(uname_S),SunOS)
 	# SunOS
         ifneq ($(@@),32bit)


### PR DESCRIPTION
Installation on a Raspberry Pi 4 fails due to Redis failing to link automatically with libatomic. Further discussion in https://github.com/redis/redis/issues/6275 and https://github.com/yahoo/redislite/issues/150

This change to the Makefile in redis.submodule (fix from https://github.com/redis/redis/commit/f5d48537f1aa76e5ce4f14953517bd25c9ad4673) explicitly links to libatomic if the architecture is ARM. With this change, compiling and linking succeeds and the installation of redislite succeeds


> I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
