### PR TITLE
Remove screwdriver manylinux1 jobs.

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -30,14 +30,6 @@ jobs:
       PUBLISH: False
     requires: [~commit, ~pr]
 
-  pkg_ml1_64:
-    template: python/package_python
-    image: manylinux1_64
-    environment:
-      PACKAGE_TYPES: wheel
-      PUBLISH: False
-    requires: [~commit, ~pr]
-
   pkg_ml2010:
     template: python/package_python
     image: manylinux2010
@@ -66,16 +58,6 @@ jobs:
       TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
     requires: [validate_test, validate_lint, validate_codestyle, validate_documentation, pkg_sdist, pkg_ml1_64, pkg_ml2010, pkg_ml2014, generate_version]
 
-  publish_test_pypi_ml1:
-    template: python/package_python
-    image: manylinux1_64
-    environment:
-      PACKAGE_TAG: False
-      PACKAGE_TYPES: wheel
-      PUBLISH: True
-      TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
-    requires: [validate_test, validate_lint, validate_codestyle, validate_documentation, pkg_sdist, pkg_ml1_64, pkg_ml2010, pkg_ml2014, generate_version]
-
   publish_test_pypi_ml2014:
     template: python/package_python
     image: manylinux2014
@@ -92,13 +74,6 @@ jobs:
         PYPI_INDEX_URL: https://test.pypi.org/simple
     requires: [publish_test_pypi]
 
-  verify_test_pkg_ml1:
-    template: python/validate_pypi_package
-    image: manylinux1_64
-    environment:
-        PYPI_INDEX_URL: https://test.pypi.org/simple
-    requires: [publish_test_pypi_ml1]
-  
   verify_test_pkg_ml2014:
     template: python/validate_pypi_package
     image: manylinux2014
@@ -118,15 +93,6 @@ jobs:
       PUBLISH: True
     requires: [verify_test_pkg, verify_test_pkg_ml1, verify_test_pkg_ml2014]
 
-  publish_pypi_ml1_64:
-    template: python/package_python
-    image: manylinux1_64
-    environment:
-      PACKAGE_TAG: False
-      PACKAGE_TYPES: wheel
-      PUBLISH: True
-    requires: [verify_test_pkg, verify_test_pkg_ml1, verify_test_pkg_ml2014]
-    
   publish_pypi_ml2014:
     template: python/package_python
     image: manylinux2014


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

The manylinux1 jobs fail due to a transitive dependency on cryptography and cffi libraries, which no longer install on the quay.io/pypa/manylinux1_x86_64 image. The quay.io/pypa/manylinux1_x86_64 image is scheduled to be EOL'd on 2022-01-01 (see: https://web.archive.org/web/20210918193655/https://github.com/pypa/manylinux#manylinux1-centos-5-based---eol).

Remove the manylinux1 jobs in anticipation of their EOL.

If the maintainers are amenable to this change, the required status checks for this repo will need to be updated to no longer require `Screwdriver/2880/PR:pkg_ml1_64`.