### PR TITLE
Respect MAKE environment variable when building Redis

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ class BuildRedis(build):
         os.environ['CC'] = 'gcc'
         os.environ['PREFIX'] = REDIS_PATH
         cmd = [
-            'make',
+            os.environ.get('MAKE', 'make'),
             'MALLOC=libc',
             'V=' + str(self.verbose),
         ]


### PR DESCRIPTION
Respect the `MAKE` environment variable, so the build can succeed on platforms where `make` is BSD make and `MAKE=gmake` is necessary to build Redis.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.