### PR TITLE
Avoid killing oneself if redis gets stuck dieing

### DIFF
--- a/redislite/client.py
+++ b/redislite/client.py
@@ -106,8 +106,8 @@ class RedisMixin(object):
                                         break
                                     time.sleep(.1)
                             if process.is_running() and process.pid != 0:
-                                logger.warning('Redis graceful shutdown failed, forcefully killing pid %r', self.pid)
-                                os.kill(self.pid, signal.SIGKILL)
+                                logger.warning('Redis graceful shutdown failed, forcefully killing pid %r', process.pid)
+                                os.kill(process.pid, signal.SIGKILL)
                         except psutil.NoSuchProcess:
                             pass
                 self.socket_file = None


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

When running redislite under GitHub Actions in an container (rather than directly on the runner) I see pytest die with exit code 137.

After some debugging I realised it's as GHA runs containers with `tail` as PID=1 which doesn't process signals correctly, so the daemonized redis-server goes `<defunct>` aka Zombie when it exits.  This sends redislite through a series of timeouts resulting in a final SIGTERM using `self.pid` which while non-zero at the start becomes zero by the time of the SIGTERM (I assume via some callback action inside the redis library this package extends), leading to a suicide.  Switching to use `process.pid` seems better for this situation & avoids the self-kill.