### PR TITLE
Fix redis download method

### DIFF
--- a/build_scripts/update_redis_server.py
+++ b/build_scripts/update_redis_server.py
@@ -8,7 +8,7 @@ import tarfile
 import tempfile
 
 
-redis_version = os.environ.get('REDIS_VERSION', '6.2.14')
+redis_version = os.environ.get('REDIS_VERSION', '6.2.17')
 url = f'http://download.redis.io/releases/redis-{redis_version}.tar.gz'
 
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -3,7 +3,7 @@ shared:
   environment:
     CHANGELOG_FILENAME: docs/source/topic/changelog.md
     PACKAGE_DIRECTORY: redislite
-    REDIS_VERSION: '6.2.14'
+    REDIS_VERSION: '6.2.17'
     TOX_ENVLIST: py38,py39,py310,py311
   steps:
     - postinit_os: build_scripts/update_redis_server.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ project_urls =
     Documentation = https://redislite.readthedocs.io/en/latest/
     Source = https://github.com/yahoo/redislite
 url = https://github.com/yahoo/redislite
-version = 6.2.14
+version = 6.2.17
 
 [options]
 install_requires=

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,11 @@ def download_redis_submodule():
         shutil.rmtree(REDIS_PATH)
     with tempfile.TemporaryDirectory() as tempdir:
         print(f'Downloading {REDIS_URL} to temp directory {tempdir}')
-        ftpstream = urllib.request.urlopen(REDIS_URL)
+        headers = {
+            'User-Agent': 'wget/1.21.2 (linux-gnu)'
+        }
+        req = urllib.request.Request(REDIS_URL, headers=headers)
+        ftpstream = urllib.request.urlopen(req)
         tf = tarfile.open(fileobj=ftpstream, mode="r|gz")
         directory = tf.next().name
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ METADATA_FILENAME = 'redislite/package_metadata.json'
 BASEPATH = os.path.dirname(os.path.abspath(__file__))
 REDIS_PATH = os.path.join(BASEPATH, 'redis.submodule')
 REDIS_SERVER_METADATA = {}
-REDIS_VERSION = os.environ.get('REDIS_VERSION', '6.2.14')
+REDIS_VERSION = os.environ.get('REDIS_VERSION', '6.2.17')
 REDIS_URL = f'http://download.redis.io/releases/redis-{REDIS_VERSION}.tar.gz'
 install_scripts = ''
 try:


### PR DESCRIPTION
- Redis download website expects the User-Agent to be set,
otherwise they will respond 403 and cause setup.py to fail
to install

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
